### PR TITLE
ignore timing out errors unless the timeout was specified to INFINITE

### DIFF
--- a/src/stdlib/child/windows.rs
+++ b/src/stdlib/child/windows.rs
@@ -84,7 +84,7 @@ impl ChildImp {
 
 		// ignore timing out errors unless the timeout was specified to INFINITE
 		// https://docs.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-getqueuedcompletionstatus
-		if timeout != INFINITE && result == FALSE && overlapped.is_null() {
+		if timeout != INFINITE && result == FALSE && overlapped.as_ptr().is_null() {
 			return Ok(());
 		}
 

--- a/src/stdlib/child/windows.rs
+++ b/src/stdlib/child/windows.rs
@@ -4,7 +4,10 @@ use std::{
 	process::{Child, ChildStderr, ChildStdin, ChildStdout, ExitStatus},
 };
 use winapi::{
-	shared::{basetsd::ULONG_PTR, minwindef::DWORD},
+	shared::{
+		basetsd::ULONG_PTR,
+		minwindef::{DWORD, FALSE},
+	},
 	um::{
 		handleapi::CloseHandle, ioapiset::GetQueuedCompletionStatus, jobapi2::TerminateJobObject,
 		minwinbase::LPOVERLAPPED, winbase::INFINITE, winnt::HANDLE,
@@ -69,7 +72,7 @@ impl ChildImp {
 		let mut key: ULONG_PTR = 0;
 		let mut overlapped = mem::MaybeUninit::<LPOVERLAPPED>::uninit();
 
-		res_bool(unsafe {
+		let result = unsafe {
 			GetQueuedCompletionStatus(
 				self.handles.completion_port,
 				&mut code,
@@ -77,7 +80,15 @@ impl ChildImp {
 				overlapped.as_mut_ptr(),
 				timeout,
 			)
-		})?;
+		};
+
+		// ignore timing out errors unless the timeout was specified to INFINITE
+		// https://docs.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-getqueuedcompletionstatus
+		if timeout != INFINITE && result == FALSE && overlapped.is_null() {
+			return Ok(());
+		}
+
+		res_bool(result)?;
 
 		Ok(())
 	}

--- a/src/tokio/child/windows.rs
+++ b/src/tokio/child/windows.rs
@@ -84,7 +84,7 @@ impl ChildImp {
 
 		// ignore timing out errors unless the timeout was specified to INFINITE
 		// https://docs.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-getqueuedcompletionstatus
-		if timeout != INFINITE && result == FALSE && overlapped.is_null() {
+		if timeout != INFINITE && result == FALSE && overlapped.as_ptr().is_null() {
 			return Ok(());
 		}
 

--- a/src/tokio/child/windows.rs
+++ b/src/tokio/child/windows.rs
@@ -4,7 +4,10 @@ use tokio::{
 	task::spawn_blocking,
 };
 use winapi::{
-	shared::{basetsd::ULONG_PTR, minwindef::DWORD},
+	shared::{
+		basetsd::ULONG_PTR,
+		minwindef::{DWORD, FALSE},
+	},
 	um::{
 		handleapi::CloseHandle, ioapiset::GetQueuedCompletionStatus, jobapi2::TerminateJobObject,
 		minwinbase::LPOVERLAPPED, winbase::INFINITE, winnt::HANDLE,

--- a/src/tokio/windows.rs
+++ b/src/tokio/windows.rs
@@ -11,7 +11,12 @@ impl AsyncCommandGroup for Command {
 		self.creation_flags(CREATE_SUSPENDED);
 
 		let child = self.spawn()?;
-		assign_child(child.raw_handle().expect("child has exited but it has not even started"), job)?;
+		assign_child(
+			child
+				.raw_handle()
+				.expect("child has exited but it has not even started"),
+			job,
+		)?;
 
 		Ok(AsyncGroupChild::new(child, job, completion_port))
 	}

--- a/src/winres.rs
+++ b/src/winres.rs
@@ -6,7 +6,7 @@ use std::{
 	ptr,
 };
 use winapi::{
-	shared::minwindef::{BOOL, DWORD, LPVOID},
+	shared::minwindef::{BOOL, DWORD, FALSE, LPVOID},
 	um::{
 		handleapi::{CloseHandle, INVALID_HANDLE_VALUE},
 		ioapiset::CreateIoCompletionPort,
@@ -48,7 +48,7 @@ pub(crate) fn res_null(handle: HANDLE) -> Result<HANDLE> {
 }
 
 pub(crate) fn res_bool(ret: BOOL) -> Result<()> {
-	if ret == 0 {
+	if ret == FALSE {
 		Err(Error::last_os_error())
 	} else {
 		Ok(())


### PR DESCRIPTION
The documentation states that for timeout failures:

> If a completion packet does not appear within the specified time, the function times out, returns FALSE, and sets *lpOverlapped to NULL.

Unless the user specified waiting for INFINITE, ignore timeout errors.

https://docs.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-getqueuedcompletionstatus