### PR TITLE
Upgrade to nix 0.24.1, limit features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,9 @@ features = ["io-util", "macros", "process", "rt"]
 optional = true
 
 [target.'cfg(unix)'.dependencies.nix]
-version = "0.22.0"
+version = "0.24.1"
+default-features = false
+features = ["poll", "signal"]
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.9"


### PR DESCRIPTION
This removes memoffset as an indirect dependency, and slightly decreases build times.