### PR TITLE
Bump MSRV and policy

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,10 +6,10 @@ jobs:
   clippy:
     strategy:
       matrix:
-        include:
-          - platform: macos
-          - platform: ubuntu
-          - platform: windows
+        platform:
+          - macos
+          - ubuntu
+          - windows
 
     name: "Clippy on ${{ matrix.platform }}"
     runs-on: "${{ matrix.platform }}-latest"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,19 +8,13 @@ jobs:
   check:
     strategy:
       matrix:
-        include:
-          - platform: macos
-            features: default
-          - platform: macos
-            features: with-tokio
-          - platform: ubuntu
-            features: default
-          - platform: ubuntu
-            features: with-tokio
-          - platform: windows
-            features: default
-          - platform: windows
-            features: with-tokio
+        platform:
+          - macos
+          - ubuntu
+          - windows
+        features:
+          - default
+          - with-tokio
 
     name: "Check on ${{ matrix.platform }} (feat: ${{ matrix.features }})"
     runs-on: "${{ matrix.platform }}-latest"

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,33 +1,25 @@
-name: Try this
+name: Merge (with Bors)
 on:
-  pull_request:
+  push:
+    branches:
+      - staging
+      - trying
 
 jobs:
   check:
     strategy:
-      fail-fast: false
       matrix:
-        platform: [macos]
+        platform:
+          - macos
+          - ubuntu
+          - windows
+        toolchain:
+          - stable
+          - 1.60.0
         features:
           - default
           - with-tokio
-        toolchain:
-          - stable
-          - 1.51.0
-          - 1.52.0
-          - 1.53.0
-          - 1.54.0
-          - 1.55.0
-          - 1.56.0
-          - 1.57.0
-          - 1.58.0
-          - 1.59.0
-          - 1.60.0
-          - 1.61.0
-          - 1.62.0
-          - 1.63.0
-          - 1.64.0
-          - 1.65.0
+
     name: "Test on ${{ matrix.platform }} with Rust ${{ matrix.toolchain }} (feat: ${{ matrix.features }})"
     runs-on: "${{ matrix.platform }}-latest"
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,52 +1,33 @@
-name: Merge (with Bors)
+name: Try this
 on:
-  push:
-    branches:
-      - staging
-      - trying
+  pull_request:
 
 jobs:
   check:
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - platform: macos
-            toolchain: stable
-            features: default
-          - platform: macos
-            toolchain: 1.51.0
-            features: default
-          - platform: macos
-            toolchain: stable
-            features: with-tokio
-          - platform: macos
-            toolchain: 1.51.0
-            features: with-tokio
-          - platform: ubuntu
-            toolchain: stable
-            features: default
-          - platform: ubuntu
-            toolchain: 1.51.0
-            features: default
-          - platform: ubuntu
-            toolchain: stable
-            features: with-tokio
-          - platform: ubuntu
-            toolchain: 1.51.0
-            features: with-tokio
-          - platform: windows
-            toolchain: stable
-            features: default
-          - platform: windows
-            toolchain: 1.51.0
-            features: default
-          - platform: windows
-            toolchain: stable
-            features: with-tokio
-          - platform: windows
-            toolchain: 1.51.0
-            features: with-tokio
-
+        platform: [macos]
+        features:
+          - default
+          - with-tokio
+        toolchain:
+          - stable
+          - 1.51.0
+          - 1.52.0
+          - 1.53.0
+          - 1.54.0
+          - 1.55.0
+          - 1.56.0
+          - 1.57.0
+          - 1.58.0
+          - 1.59.0
+          - 1.60.0
+          - 1.61.0
+          - 1.62.0
+          - 1.63.0
+          - 1.64.0
+          - 1.65.0
     name: "Test on ${{ matrix.platform }} with Rust ${{ matrix.toolchain }} (feat: ${{ matrix.features }})"
     runs-on: "${{ matrix.platform }}-latest"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,9 @@ homepage = "https://github.com/watchexec/command-group"
 repository = "https://github.com/watchexec/command-group"
 readme = "README.md"
 
-edition = "2018"
+edition = "2021"
 exclude = ["/bin", "/.github"]
+rust-version = "1.60.0"
 
 [dependencies]
 async-trait = { version = "0.1.50", optional = true }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![Crate release version](https://flat.badgen.net/crates/v/command-group)](https://crates.io/crates/command-group)
 [![Crate license: Apache 2.0 or MIT](https://flat.badgen.net/badge/license/Apache%202.0%20or%20MIT)][copyright]
-![MSRV: 1.51.0 (breaking)](https://flat.badgen.net/badge/MSRV/1.51.0%20%28breaking%29/green)
 [![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/45673)
 [![CI status on main branch](https://github.com/watchexec/command-group/actions/workflows/main.yml/badge.svg)](https://github.com/watchexec/command-group/actions/workflows/main.yml)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ _Extension to [`Command`](https://doc.rust-lang.org/std/process/struct.Command.h
 
 - **[API documentation][docs]**.
 - [Dual-licensed][copyright] with Apache 2.0 and MIT.
-- Minimum Supported Rust Version: 1.51.0.
+- Minimum Supported Rust Version: 1.60.0.
+  - This is set as: 5 versions before stable, at the time of publish.
 
 [caretaker]: ./CARETAKERS.md
 [copyright]: ./COPYRIGHT


### PR DESCRIPTION
This will incur a major bump to respect prior MSRV policy, but then as of this PR policy changes to not require that, and instead only actively support latest 5 stables.