### PR TITLE
Group Builder API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
 
-      - run: cargo test --features ${{ matrix.features }}
+      - run: cargo test --features ${{ matrix.features }} --all-targets
       - run: cargo clippy --features ${{ matrix.features }}
 
   formatting:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,9 @@ all-features = true
 name = "basic"
 
 [[example]]
+name = "builder"
+
+[[example]]
 name = "async"
 required-features = ["with-tokio"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ edition = "2021"
 exclude = ["/bin", "/.github"]
 rust-version = "1.60.0"
 
+# there are a few windows-specific ones
+autoexamples = false
+
 [dependencies]
 async-trait = { version = "0.1.50", optional = true }
 
@@ -50,3 +53,22 @@ tokio = { version = "1.10.0", features = ["io-util", "macros", "process", "rt", 
 
 [package.metadata.docs.rs]
 all-features = true
+
+[[example]]
+name = "basic"
+
+[[example]]
+name = "async"
+required-features = ["with-tokio"]
+
+[[example]]
+name = "kill_on_drop"
+required-features = ["with-tokio"]
+
+[[example]]
+name = "daemon"
+required-features = ["with-tokio"]
+
+[[target.'cfg(windows)'.example]]
+name = "with_flags"
+required-features = ["with-tokio"]

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,0 +1,12 @@
+//! This example shows the basic usage of the async version
+//! of the `group_spawn` method, and collects the exit code.
+
+use command_group::AsyncCommandGroup;
+
+#[tokio::main]
+async fn main() {
+	let mut handle = tokio::process::Command::new("ls").group_spawn().unwrap();
+	println!("{:?}", handle);
+	let exit_code = handle.wait().await;
+	println!("{:?}", exit_code);
+}

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,11 @@
+//! This example shows the basic usage of the sync version
+//! of the `group_spawn` method, and collects the exit code.
+
+use command_group::CommandGroup;
+
+fn main() {
+	let mut handle = std::process::Command::new("ls").group_spawn().unwrap();
+	println!("{:?}", handle);
+	let exit_code = handle.wait();
+	println!("{:?}", exit_code);
+}

--- a/examples/builder.rs
+++ b/examples/builder.rs
@@ -1,0 +1,12 @@
+//! This example shows the basic usage of the sync version
+//! of the `group` method, and collects the exit code. The
+//! group builder gives more control over the process group.
+
+use command_group::CommandGroup;
+
+fn main() {
+	let mut handle = std::process::Command::new("ls").group().spawn().unwrap();
+	println!("{:?}", handle);
+	let exit_code = handle.wait();
+	println!("{:?}", exit_code);
+}

--- a/examples/daemon.rs
+++ b/examples/daemon.rs
@@ -1,0 +1,21 @@
+//! This example shows how to use the `group_spawn` method
+//! to spawn a python server daemon in the background.
+//!
+//! NOTE: This example will not work on Windows, as the
+//! `kill_on_drop` flag is not supported via this API.
+//!
+//! See the `kill_on_drop` example for a Windows-compatible
+//! example.
+
+use std::process::Stdio;
+
+use command_group::AsyncCommandGroup;
+
+#[tokio::main]
+async fn main() {
+	tokio::process::Command::new("python3")
+		.args(&["-m", "http.server", "8000"])
+		.stderr(Stdio::null())
+		.stdout(Stdio::null())
+		.group_spawn();
+}

--- a/examples/daemon.rs
+++ b/examples/daemon.rs
@@ -17,5 +17,6 @@ async fn main() {
 		.args(&["-m", "http.server", "8000"])
 		.stderr(Stdio::null())
 		.stdout(Stdio::null())
-		.group_spawn();
+		.group_spawn()
+		.expect("failed to spawn server");
 }

--- a/examples/kill_on_drop.rs
+++ b/examples/kill_on_drop.rs
@@ -1,0 +1,19 @@
+//! This example shows how to use the `group` builder
+//! to spawn a python server daemon in the background,
+//! while supporting windows by explicitly setting the
+//! `kill_on_drop` flag.
+
+use std::process::Stdio;
+
+use command_group::AsyncCommandGroup;
+
+#[tokio::main]
+async fn main() {
+	tokio::process::Command::new("python3")
+		.args(&["-m", "http.server", "8000"])
+		.stderr(Stdio::null())
+		.stdout(Stdio::null())
+		.group()
+		.kill_on_drop(true)
+		.spawn();
+}

--- a/examples/kill_on_drop.rs
+++ b/examples/kill_on_drop.rs
@@ -15,5 +15,6 @@ async fn main() {
 		.stdout(Stdio::null())
 		.group()
 		.kill_on_drop(true)
-		.spawn();
+		.spawn()
+		.expect("failed to spawn server");
 }

--- a/examples/with_flags.rs
+++ b/examples/with_flags.rs
@@ -1,0 +1,20 @@
+//! This example shows how to use the `group` builder
+//! to spawn a python server daemon in the background,
+//! while setting creation flags on windows to hide the
+//! console window.
+
+use std::process::Stdio;
+
+use command_group::AsyncCommandGroup;
+use winapi::um::winbase::CREATE_NO_WINDOW;
+
+#[tokio::main]
+async fn main() {
+	let group = tokio::process::Command::new("python3")
+		.args(&["-m", "http.server", "8000"])
+		.stderr(Stdio::null())
+		.stdout(Stdio::null())
+		.group()
+		.creation_flags(CREATE_NO_WINDOW)
+		.spawn();
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,24 @@
+/// GroupBuilder is a builder for a group of processes.
+///
+/// It is created via the `group` method on [`Command`](std::process::Command) or
+/// [`AsyncCommand`](tokio::process::Command).
+pub struct GroupBuilder<'a, T> {
+	pub(crate) command: &'a mut T,
+	pub(crate) kill_on_drop: bool,
+	pub(crate) creation_flags: u32,
+}
+
+impl<'a, T> GroupBuilder<'a, T> {
+	pub(crate) fn new(command: &'a mut T) -> Self {
+		Self {
+			command,
+			kill_on_drop: false,
+			creation_flags: 0,
+		}
+	}
+
+	pub fn creation_flags(mut self, creation_flags: u32) -> Self {
+		self.creation_flags = creation_flags;
+		self
+	}
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,14 +1,18 @@
-/// GroupBuilder is a builder for a group of processes.
+//!
+
+/// CommandGroupBuilder is a builder for a group of processes.
 ///
 /// It is created via the `group` method on [`Command`](std::process::Command) or
 /// [`AsyncCommand`](tokio::process::Command).
-pub struct GroupBuilder<'a, T> {
+pub struct CommandGroupBuilder<'a, T> {
 	pub(crate) command: &'a mut T,
+	#[allow(dead_code)]
 	pub(crate) kill_on_drop: bool,
+	#[allow(dead_code)]
 	pub(crate) creation_flags: u32,
 }
 
-impl<'a, T> GroupBuilder<'a, T> {
+impl<'a, T> CommandGroupBuilder<'a, T> {
 	pub(crate) fn new(command: &'a mut T) -> Self {
 		Self {
 			command,
@@ -17,7 +21,16 @@ impl<'a, T> GroupBuilder<'a, T> {
 		}
 	}
 
-	pub fn creation_flags(mut self, creation_flags: u32) -> Self {
+	/// See [`tokio::process::Command::kill_on_drop`].
+	#[cfg(any(target_os = "windows", feature = "with-tokio"))]
+	pub fn kill_on_drop(&mut self, kill_on_drop: bool) -> &mut Self {
+		self.kill_on_drop = kill_on_drop;
+		self
+	}
+
+	/// Set the creation flags for the process.
+	#[cfg(any(target_os = "windows"))]
+	pub fn creation_flags(&mut self, creation_flags: u32) -> &mut Self {
 		self.creation_flags = creation_flags;
 		self
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@ mod unix_ext;
 #[cfg(feature = "with-tokio")]
 pub mod tokio;
 
+pub mod builder;
+
 #[cfg(windows)]
 pub(crate) mod winres;
 

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -6,7 +6,7 @@ use std::{
 	process::{ExitStatus, Output},
 };
 
-use crate::{builder::GroupBuilder, GroupChild};
+use crate::{builder::CommandGroupBuilder, GroupChild};
 
 #[cfg(target_family = "windows")]
 mod windows;
@@ -41,9 +41,9 @@ pub trait CommandGroup {
 	/// ```
 	fn group_spawn(&mut self) -> Result<GroupChild>;
 
-	/// Converts the implementor into a [`GroupBuilder`](crate::GroupBuilder), which can be used to
+	/// Converts the implementor into a [`CommandGroupBuilder`](crate::CommandGroupBuilder), which can be used to
 	/// set flags that are not available on the `Command` type.
-	fn group(&mut self) -> GroupBuilder<std::process::Command>;
+	fn group(&mut self) -> CommandGroupBuilder<std::process::Command>;
 
 	/// Executes the command as a child process group, waiting for it to finish and
 	/// collecting all of its output.

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -6,7 +6,7 @@ use std::{
 	process::{ExitStatus, Output},
 };
 
-use crate::GroupChild;
+use crate::{builder::GroupBuilder, GroupChild};
 
 #[cfg(target_family = "windows")]
 mod windows;
@@ -40,6 +40,10 @@ pub trait CommandGroup {
 	///         .expect("ls command failed to start");
 	/// ```
 	fn group_spawn(&mut self) -> Result<GroupChild>;
+
+	/// Converts the implementor into a [`GroupBuilder`](crate::GroupBuilder), which can be used to
+	/// set flags that are not available on the `Command` type.
+	fn group(&mut self) -> GroupBuilder<std::process::Command>;
 
 	/// Executes the command as a child process group, waiting for it to finish and
 	/// collecting all of its output.

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -3,7 +3,7 @@
 
 use std::{
 	io::Result,
-	process::{ExitStatus, Output},
+	process::{Command, ExitStatus, Output},
 };
 
 use crate::{builder::CommandGroupBuilder, GroupChild};
@@ -17,9 +17,6 @@ mod unix;
 pub(crate) mod child;
 
 /// Extensions for [`Command`](std::process::Command) adding support for process groups.
-///
-/// At the moment, `kill_on_drop(false)` is not supported on Windows, and may or may not work on
-/// other platforms.
 pub trait CommandGroup {
 	/// Executes the command as a child process group, returning a handle to it.
 	///
@@ -39,7 +36,9 @@ pub trait CommandGroup {
 	///         .group_spawn()
 	///         .expect("ls command failed to start");
 	/// ```
-	fn group_spawn(&mut self) -> Result<GroupChild>;
+	fn group_spawn(&mut self) -> Result<GroupChild> {
+		self.group().spawn()
+	}
 
 	/// Converts the implementor into a [`CommandGroupBuilder`](crate::CommandGroupBuilder), which can be used to
 	/// set flags that are not available on the `Command` type.
@@ -102,5 +101,11 @@ pub trait CommandGroup {
 	/// ```
 	fn group_status(&mut self) -> Result<ExitStatus> {
 		self.group_spawn().and_then(|mut child| child.wait())
+	}
+}
+
+impl CommandGroup for Command {
+	fn group<'a>(&'a mut self) -> CommandGroupBuilder<'a, Command> {
+		CommandGroupBuilder::new(self)
 	}
 }

--- a/src/stdlib/unix.rs
+++ b/src/stdlib/unix.rs
@@ -4,7 +4,7 @@ use std::{
 	process::Command,
 };
 
-use crate::{CommandGroup, GroupChild};
+use crate::{builder::CommandGroupBuilder, CommandGroup, GroupChild};
 use nix::unistd::setsid;
 
 impl CommandGroup for Command {
@@ -16,7 +16,32 @@ impl CommandGroup for Command {
 		self.spawn().map(GroupChild::new)
 	}
 
-	fn group(&mut self) -> crate::builder::GroupBuilder<std::process::Command> {
-		crate::builder::GroupBuilder::new(self)
+	fn group(&mut self) -> CommandGroupBuilder<Command> {
+		CommandGroupBuilder::new(self)
+	}
+}
+
+impl CommandGroupBuilder<'_, Command> {
+	/// Executes the command as a child process group, returning a handle to it.
+	///
+	/// By default, stdin, stdout and stderr are inherited from the parent.
+	///
+	/// On Windows, this creates a job object instead of a POSIX process group.
+	///
+	/// # Examples
+	///
+	/// Basic usage:
+	///
+	/// ```no_run
+	/// use std::process::Command;
+	/// use command_group::CommandGroup;
+	///
+	/// Command::new("ls")
+	///         .group()
+	/// 		.spawn()
+	///         .expect("ls command failed to start");
+	/// ```
+	pub fn spawn(&mut self) -> std::io::Result<GroupChild> {
+		self.command.group_spawn()
 	}
 }

--- a/src/stdlib/unix.rs
+++ b/src/stdlib/unix.rs
@@ -15,4 +15,8 @@ impl CommandGroup for Command {
 
 		self.spawn().map(GroupChild::new)
 	}
+
+	fn group(&mut self) -> crate::builder::GroupBuilder<std::process::Command> {
+		crate::builder::GroupBuilder::new(self)
+	}
 }

--- a/src/stdlib/windows.rs
+++ b/src/stdlib/windows.rs
@@ -1,26 +1,10 @@
 use std::{
-	io::Result,
 	os::windows::{io::AsRawHandle, process::CommandExt},
 	process::Command,
 };
 use winapi::um::winbase::CREATE_SUSPENDED;
 
-use crate::{builder::CommandGroupBuilder, winres::*, CommandGroup, GroupChild};
-
-impl CommandGroup for Command {
-	fn group_spawn(&mut self) -> Result<GroupChild> {
-		let (job, completion_port) = job_object(true)?;
-		self.creation_flags(CREATE_SUSPENDED);
-		let child = self.spawn()?;
-		assign_child(child.as_raw_handle(), job)?;
-
-		Ok(GroupChild::new(child, job, completion_port))
-	}
-
-	fn group<'a>(&'a mut self) -> CommandGroupBuilder<'a, Command> {
-		CommandGroupBuilder::new(self)
-	}
-}
+use crate::{builder::CommandGroupBuilder, winres::*, GroupChild};
 
 impl CommandGroupBuilder<'_, Command> {
 	/// Executes the command as a child process group, returning a handle to it.

--- a/src/stdlib/windows.rs
+++ b/src/stdlib/windows.rs
@@ -5,12 +5,31 @@ use std::{
 };
 use winapi::um::winbase::CREATE_SUSPENDED;
 
-use crate::{winres::*, CommandGroup, GroupChild};
+use crate::{builder::GroupBuilder, winres::*, CommandGroup, GroupChild};
 
 impl CommandGroup for Command {
 	fn group_spawn(&mut self) -> Result<GroupChild> {
-		let (job, completion_port) = job_object()?;
+		let (job, completion_port) = job_object(true)?;
 		self.creation_flags(CREATE_SUSPENDED);
+		let child = self.spawn()?;
+		assign_child(child.as_raw_handle(), job)?;
+
+		Ok(GroupChild::new(child, job, completion_port))
+	}
+
+	fn group(self) -> GroupBuilder<Command> {
+		GroupBuilder::new(self)
+	}
+}
+
+impl GroupBuilder<std::process::Command> {
+	pub fn spawn(&mut self) -> std::io::Result<GroupChild> {
+		self.command
+			.creation_flags(self.creation_flags | CREATE_SUSPENDED);
+
+		// note: same a as in CommandGroup::group_spawn
+		// but without creation_flags(CREATE_SUSPENDED)
+		let (job, completion_port) = job_object(self.kill_on_drop)?;
 		let child = self.spawn()?;
 		assign_child(child.as_raw_handle(), job)?;
 

--- a/src/stdlib/windows.rs
+++ b/src/stdlib/windows.rs
@@ -30,8 +30,6 @@ impl CommandGroupBuilder<'_, Command> {
 		self.command
 			.creation_flags(self.creation_flags | CREATE_SUSPENDED);
 
-		// note: same a as in CommandGroup::group_spawn
-		// but without creation_flags(CREATE_SUSPENDED)
 		let (job, completion_port) = job_object(self.kill_on_drop)?;
 		let child = self.command.spawn()?;
 		assign_child(child.as_raw_handle(), job)?;

--- a/src/stdlib/windows.rs
+++ b/src/stdlib/windows.rs
@@ -5,7 +5,7 @@ use std::{
 };
 use winapi::um::winbase::CREATE_SUSPENDED;
 
-use crate::{builder::GroupBuilder, winres::*, CommandGroup, GroupChild};
+use crate::{builder::CommandGroupBuilder, winres::*, CommandGroup, GroupChild};
 
 impl CommandGroup for Command {
 	fn group_spawn(&mut self) -> Result<GroupChild> {
@@ -17,12 +17,31 @@ impl CommandGroup for Command {
 		Ok(GroupChild::new(child, job, completion_port))
 	}
 
-	fn group(self) -> GroupBuilder<Command> {
-		GroupBuilder::new(self)
+	fn group<'a>(&'a mut self) -> CommandGroupBuilder<'a, Command> {
+		CommandGroupBuilder::new(self)
 	}
 }
 
-impl GroupBuilder<std::process::Command> {
+impl CommandGroupBuilder<'_, Command> {
+	/// Executes the command as a child process group, returning a handle to it.
+	///
+	/// By default, stdin, stdout and stderr are inherited from the parent.
+	///
+	/// On Windows, this creates a job object instead of a POSIX process group.
+	///
+	/// # Examples
+	///
+	/// Basic usage:
+	///
+	/// ```no_run
+	/// use std::process::Command;
+	/// use command_group::CommandGroup;
+	///
+	/// Command::new("ls")
+	///         .group()
+	/// 		.spawn()
+	///         .expect("ls command failed to start");
+	/// ```
 	pub fn spawn(&mut self) -> std::io::Result<GroupChild> {
 		self.command
 			.creation_flags(self.creation_flags | CREATE_SUSPENDED);
@@ -30,7 +49,7 @@ impl GroupBuilder<std::process::Command> {
 		// note: same a as in CommandGroup::group_spawn
 		// but without creation_flags(CREATE_SUSPENDED)
 		let (job, completion_port) = job_object(self.kill_on_drop)?;
-		let child = self.spawn()?;
+		let child = self.command.spawn()?;
 		assign_child(child.as_raw_handle(), job)?;
 
 		Ok(GroupChild::new(child, job, completion_port))

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -6,7 +6,9 @@ use std::{
 	process::{ExitStatus, Output},
 };
 
-use crate::AsyncGroupChild;
+use tokio::process::Command;
+
+use crate::{builder::CommandGroupBuilder, AsyncGroupChild};
 
 #[cfg(target_family = "windows")]
 mod windows;
@@ -19,9 +21,6 @@ pub(crate) mod child;
 /// Extensions for [`Command`](::tokio::process::Command) adding support for process groups.
 ///
 /// This uses [`async_trait`] for now to provide async methods as a trait.
-///
-/// At the moment, `kill_on_drop(false)` is not supported on Windows, and may or may not work on
-/// other platforms.
 #[async_trait::async_trait]
 pub trait AsyncCommandGroup {
 	/// Executes the command as a child process group, returning a handle to it.
@@ -45,7 +44,9 @@ pub trait AsyncCommandGroup {
 	///         .expect("ls command failed to start");
 	/// # }
 	/// ```
-	fn group_spawn(&mut self) -> Result<AsyncGroupChild>;
+	fn group_spawn(&mut self) -> Result<AsyncGroupChild> {
+		self.group().spawn()
+	}
 
 	/// Converts the implementor into a [`CommandGroupBuilder`](crate::CommandGroupBuilder), which can be used to
 	/// set flags that are not available on the `Command` type.
@@ -117,5 +118,12 @@ pub trait AsyncCommandGroup {
 	async fn group_status(&mut self) -> Result<ExitStatus> {
 		let mut child = self.group_spawn()?;
 		child.wait().await
+	}
+}
+
+#[async_trait::async_trait]
+impl AsyncCommandGroup for Command {
+	fn group<'a>(&'a mut self) -> CommandGroupBuilder<'a, Command> {
+		CommandGroupBuilder::new(self)
 	}
 }

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -47,7 +47,9 @@ pub trait AsyncCommandGroup {
 	/// ```
 	fn group_spawn(&mut self) -> Result<AsyncGroupChild>;
 
-	fn group(&mut self) -> crate::builder::GroupBuilder<tokio::process::Command>;
+	/// Converts the implementor into a [`CommandGroupBuilder`](crate::CommandGroupBuilder), which can be used to
+	/// set flags that are not available on the `Command` type.
+	fn group(&mut self) -> crate::builder::CommandGroupBuilder<tokio::process::Command>;
 
 	/// Executes the command as a child process group, waiting for it to finish and
 	/// collecting all of its output.
@@ -115,19 +117,5 @@ pub trait AsyncCommandGroup {
 	async fn group_status(&mut self) -> Result<ExitStatus> {
 		let mut child = self.group_spawn()?;
 		child.wait().await
-	}
-}
-
-impl crate::builder::GroupBuilder<'_, tokio::process::Command> {
-	pub fn kill_on_drop(mut self, kill_on_drop: bool) -> Self {
-		self.kill_on_drop = kill_on_drop;
-		self
-	}
-
-	pub fn spawn(mut self) -> Result<AsyncGroupChild> {
-		self.command.kill_on_drop(self.kill_on_drop);
-		#[cfg(target_os = "windows")]
-		self.command.creation_flags(self.creation_flags);
-		self.command.group_spawn()
 	}
 }

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -47,6 +47,8 @@ pub trait AsyncCommandGroup {
 	/// ```
 	fn group_spawn(&mut self) -> Result<AsyncGroupChild>;
 
+	fn group(&mut self) -> crate::builder::GroupBuilder<tokio::process::Command>;
+
 	/// Executes the command as a child process group, waiting for it to finish and
 	/// collecting all of its output.
 	///
@@ -113,5 +115,19 @@ pub trait AsyncCommandGroup {
 	async fn group_status(&mut self) -> Result<ExitStatus> {
 		let mut child = self.group_spawn()?;
 		child.wait().await
+	}
+}
+
+impl crate::builder::GroupBuilder<'_, tokio::process::Command> {
+	pub fn kill_on_drop(mut self, kill_on_drop: bool) -> Self {
+		self.kill_on_drop = kill_on_drop;
+		self
+	}
+
+	pub fn spawn(mut self) -> Result<AsyncGroupChild> {
+		self.command.kill_on_drop(self.kill_on_drop);
+		#[cfg(target_os = "windows")]
+		self.command.creation_flags(self.creation_flags);
+		self.command.group_spawn()
 	}
 }

--- a/src/tokio/unix.rs
+++ b/src/tokio/unix.rs
@@ -13,4 +13,8 @@ impl AsyncCommandGroup for Command {
 
 		self.spawn().map(AsyncGroupChild::new)
 	}
+
+	fn group(&mut self) -> crate::builder::GroupBuilder<tokio::process::Command> {
+		crate::builder::GroupBuilder::new(self)
+	}
 }

--- a/src/tokio/unix.rs
+++ b/src/tokio/unix.rs
@@ -1,5 +1,6 @@
 use std::io::{Error, Result};
 
+use crate::builder::CommandGroupBuilder;
 use crate::{AsyncCommandGroup, AsyncGroupChild};
 use nix::unistd::setsid;
 use tokio::process::Command;
@@ -14,7 +15,32 @@ impl AsyncCommandGroup for Command {
 		self.spawn().map(AsyncGroupChild::new)
 	}
 
-	fn group(&mut self) -> crate::builder::GroupBuilder<tokio::process::Command> {
-		crate::builder::GroupBuilder::new(self)
+	fn group(&mut self) -> crate::builder::CommandGroupBuilder<tokio::process::Command> {
+		crate::builder::CommandGroupBuilder::new(self)
+	}
+}
+
+impl CommandGroupBuilder<'_, tokio::process::Command> {
+	/// Executes the command as a child process group, returning a handle to it.
+	///
+	/// By default, stdin, stdout and stderr are inherited from the parent.
+	///
+	/// On Windows, this creates a job object instead of a POSIX process group.
+	///
+	/// # Examples
+	///
+	/// Basic usage:
+	///
+	/// ```no_run
+	/// use std::process::Command;
+	/// use command_group::CommandGroup;
+	///
+	/// Command::new("ls")
+	///         .group()
+	/// 		.spawn()
+	///         .expect("ls command failed to start");
+	/// ```
+	pub fn spawn(&mut self) -> std::io::Result<AsyncGroupChild> {
+		self.command.group_spawn()
 	}
 }

--- a/src/tokio/windows.rs
+++ b/src/tokio/windows.rs
@@ -2,12 +2,12 @@ use std::io::Result;
 use tokio::process::Command;
 use winapi::um::winbase::CREATE_SUSPENDED;
 
-use crate::{winres::*, AsyncCommandGroup, AsyncGroupChild};
+use crate::{builder::CommandGroupBuilder, winres::*, AsyncCommandGroup, AsyncGroupChild};
 
 #[async_trait::async_trait]
 impl AsyncCommandGroup for Command {
 	fn group_spawn(&mut self) -> Result<AsyncGroupChild> {
-		let (job, completion_port) = job_object()?;
+		let (job, completion_port) = job_object(true)?;
 		self.creation_flags(CREATE_SUSPENDED);
 
 		let child = self.spawn()?;
@@ -21,7 +21,46 @@ impl AsyncCommandGroup for Command {
 		Ok(AsyncGroupChild::new(child, job, completion_port))
 	}
 
-	fn group(self) -> crate::builder::GroupBuilder<tokio::process::Command> {
-		crate::builder::GroupBuilder::new(self)
+	fn group<'a>(&'a mut self) -> CommandGroupBuilder<'a, Command> {
+		CommandGroupBuilder::new(self)
+	}
+}
+
+impl CommandGroupBuilder<'_, Command> {
+	/// Executes the command as a child process group, returning a handle to it.
+	///
+	/// By default, stdin, stdout and stderr are inherited from the parent.
+	///
+	/// On Windows, this creates a job object instead of a POSIX process group.
+	///
+	/// # Examples
+	///
+	/// Basic usage:
+	///
+	/// ```no_run
+	/// use std::process::Command;
+	/// use command_group::CommandGroup;
+	///
+	/// Command::new("ls")
+	///         .group()
+	/// 		.spawn()
+	///         .expect("ls command failed to start");
+	/// ```
+	pub fn spawn(&mut self) -> std::io::Result<AsyncGroupChild> {
+		self.command
+			.creation_flags(self.creation_flags | CREATE_SUSPENDED);
+
+		// note: same a as in AsyncCommandGroup::group_spawn
+		// but without creation_flags(CREATE_SUSPENDED)
+		let (job, completion_port) = job_object(self.kill_on_drop)?;
+		let child = self.command.spawn()?;
+		assign_child(
+			child
+				.raw_handle()
+				.expect("child has exited but it has not even started"),
+			job,
+		)?;
+
+		Ok(AsyncGroupChild::new(child, job, completion_port))
 	}
 }

--- a/src/tokio/windows.rs
+++ b/src/tokio/windows.rs
@@ -20,4 +20,8 @@ impl AsyncCommandGroup for Command {
 
 		Ok(AsyncGroupChild::new(child, job, completion_port))
 	}
+
+	fn group(self) -> crate::builder::GroupBuilder<tokio::process::Command> {
+		crate::builder::GroupBuilder::new(self)
+	}
 }

--- a/src/winres.rs
+++ b/src/winres.rs
@@ -63,7 +63,7 @@ pub(crate) fn res_neg(ret: DWORD) -> Result<DWORD> {
 	}
 }
 
-pub(crate) fn job_object() -> Result<(HANDLE, HANDLE)> {
+pub(crate) fn job_object(kill_on_drop: bool) -> Result<(HANDLE, HANDLE)> {
 	let job = res_null(unsafe { CreateJobObjectW(ptr::null_mut(), ptr::null()) })?;
 
 	let completion_port =
@@ -86,7 +86,11 @@ pub(crate) fn job_object() -> Result<(HANDLE, HANDLE)> {
 	})?;
 
 	let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
-	info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+	if (kill_on_drop) {
+		info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+	}
+
 	res_bool(unsafe {
 		SetInformationJobObject(
 			job,

--- a/src/winres.rs
+++ b/src/winres.rs
@@ -87,7 +87,7 @@ pub(crate) fn job_object(kill_on_drop: bool) -> Result<(HANDLE, HANDLE)> {
 
 	let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
 
-	if (kill_on_drop) {
+	if kill_on_drop {
 		info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
 	}
 


### PR DESCRIPTION
This introduces a new API with a builder pattern for setting certain flags that are not accessible to the group_spawn function if set on the Command object itself.

It also adds a few examples for basic sync, async, and a few with the builder as well.