### PR TITLE
Add command accessors to `CommandGroupBuilder`

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -21,6 +21,16 @@ impl<'a, T> CommandGroupBuilder<'a, T> {
 		}
 	}
 
+	/// Get a reference to the command contained in this builder.
+	pub fn command(&self) -> &T {
+		&*self.command
+	}
+
+	/// Get a mutable reference to the command contained in this builder.
+	pub fn command_mut(&mut self) -> &mut T {
+		self.command
+	}
+
 	/// See [`tokio::process::Command::kill_on_drop`].
 	#[cfg(any(windows, feature = "with-tokio"))]
 	pub fn kill_on_drop(&mut self, kill_on_drop: bool) -> &mut Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ mod unix_ext;
 pub mod tokio;
 
 pub mod builder;
+pub use builder::CommandGroupBuilder;
 
 #[cfg(windows)]
 pub(crate) mod winres;


### PR DESCRIPTION
Hello! I'm implementing [`command-error`](https://docs.rs/command-error/latest/command_error/), a crate that provides nicer error messages for commands, like this:

```
`sh` failed: exit status: 1
Command failed: `sh -c 'echo puppy; false'`
Stdout:
  puppy
```

I'd like to add optional support for the `command-group` crate (https://github.com/9999years/command-error/issues/2). Because traits can only be implemented once per type (and I think a generic trait would have poor ergonomics here), I'm attempting to `impl command_error::CommandExt for command_group::builder::CommandGroupBuilder<'_, std::process::Command>`, but it's not possible to access the underlying `Command` (to produce the name of the program that was run for error messages) with the current API.

Therefore, this PR adds getters to access the `Command` field of `CommandGroupBuilder`.